### PR TITLE
Docker file for running the plugin on a GPU

### DIFF
--- a/DockerFile_gpu
+++ b/DockerFile_gpu
@@ -82,13 +82,6 @@ RUN apt-get update \
   && apt-get install python3-webob                                    \
   && apt install -y python3-tk
 
-#Sina
-#RUN DEBIAN_FRONTEND=noninteractive apt-get install lightdm -y
-#RUN apt-get install -y cuda-9-0 
-#RUN apt-get remove -y nvidia-390 nvidia-390-dev
-
-#RUN apt-get install libcublas9.0 libcusolver9.0 libcudart9.0 libcufft9.0 libcurand9.0
-#RUN apt-get install cuda-cublas-9-0
 
 RUN pip install -r requirements.txt
 

--- a/DockerFile_gpu
+++ b/DockerFile_gpu
@@ -1,0 +1,97 @@
+##################### Nvidia Cuda-Cudnn: 9.0-base, 9.0-base-ubuntu16.04 #####################
+
+FROM ubuntu:16.04
+LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
+
+RUN NVIDIA_GPGKEY_SUM=d1be581509378368edeec8c1eb2958702feedf3bc3d17011adbf24efacce4ab5 && \
+    NVIDIA_GPGKEY_FPR=ae09fe4bbd223a84b2ccfce3f60f4b3d7fa2af80 && \
+    apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/7fa2af80.pub && \
+    apt-key adv --export --no-emit-version -a $NVIDIA_GPGKEY_FPR | tail -n +5 > cudasign.pub && \
+    echo "$NVIDIA_GPGKEY_SUM  cudasign.pub" | sha256sum -c --strict - && rm cudasign.pub && \
+    echo "deb http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64 /" > /etc/apt/sources.list.d/cuda.list && \
+    echo "deb http://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1604/x86_64 /" > /etc/apt/sources.list.d/nvidia-ml.list
+
+ENV CUDA_VERSION 9.0.176
+
+ENV CUDA_PKG_VERSION 9-0=$CUDA_VERSION-1
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        cuda-cudart-$CUDA_PKG_VERSION cuda-cublas-$CUDA_PKG_VERSION cuda-cusolver-$CUDA_PKG_VERSION cuda-cufft-$CUDA_PKG_VERSION cuda-curand-$CUDA_PKG_VERSION cuda-cusparse-$CUDA_PKG_VERSION && \
+    ln -s cuda-9.0 /usr/local/cuda && \
+    rm -rf /var/lib/apt/lists/*
+
+# nvidia-docker 1.0
+LABEL com.nvidia.volumes.needed="nvidia_driver"
+LABEL com.nvidia.cuda.version="${CUDA_VERSION}"
+
+RUN echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf && \
+    echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
+
+ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
+ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
+
+# nvidia-container-runtime
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+ENV NVIDIA_REQUIRE_CUDA "cuda>=9.0"
+
+
+
+##################### Nvidia Cuda-Cudnn: 9.0-cudnn7-runtime, 9.0-cudnn7-runtime-ubuntu16.04 #####################
+
+ENV CUDNN_VERSION 7.0.5.15
+LABEL com.nvidia.cudnn.version="${CUDNN_VERSION}"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+            libcudnn7=$CUDNN_VERSION-1+cuda9.0 && \
+    rm -rf /var/lib/apt/lists/*
+
+
+
+##################### FNNDSC/ubuntu-python3 #####################
+
+RUN apt-get update \
+  && apt-get install -y python3-pip python3-dev \
+  && cd /usr/local/bin \
+  && ln -s /usr/bin/python3 python \
+  && pip3 install --upgrade pip
+
+ENTRYPOINT ["python3"]
+
+
+
+##################### FNNDSC/pl-neuproseg #####################
+
+
+# Pass a UID on build command line (see above) to set internal UID
+ARG UID=1001
+ENV UID=$UID
+
+ENV APPROOT="/usr/src/neuproseg"  VERSION="0.99.9"
+COPY ["neuproseg", "${APPROOT}"]
+COPY ["requirements.txt", "${APPROOT}"]
+
+WORKDIR $APPROOT
+
+RUN apt-get update \
+  && apt-get install sudo                                             \
+  && useradd -u $UID -ms /bin/bash localuser                          \
+  && addgroup localuser sudo                                          \
+  && echo "localuser:localuser" | chpasswd                            \
+  && adduser localuser sudo                                           \
+  && apt-get install -y libssl-dev libcurl4-openssl-dev bsdmainutils vim net-tools inetutils-ping \
+  && apt-get install python3-webob                                    \
+  && apt install -y python3-tk
+
+#Sina
+#RUN DEBIAN_FRONTEND=noninteractive apt-get install lightdm -y
+#RUN apt-get install -y cuda-9-0 
+#RUN apt-get remove -y nvidia-390 nvidia-390-dev
+
+#RUN apt-get install libcublas9.0 libcusolver9.0 libcudart9.0 libcufft9.0 libcurand9.0
+#RUN apt-get install cuda-cublas-9-0
+
+RUN pip install -r requirements.txt
+
+CMD ["neuproseg.py", "--json"]
+
+


### PR DESCRIPTION
This docker file has been created in order to allow the plugin to run on an Nvidia GPU. The docker file has the necessary settings for running the TensorFlow API (which is used in the plugin) to run on a GPU.

Before using this docker file please make sure that you have the required installation of “nvidia-docker” utility in order to allow a docker container to use a GPU. Please follow the steps in [1] for installing “nvidia-docker” utility and registering the “nvidia runtime”.

If you have the required installation for the “nvidia-docker”, then you can build an image from the docker file with the following command:

-------
> sudo docker build -t="pl-neuproseg-gpu" .
-------

Note: please note that the docker file name should be renamed from “Dockerfile-gpu” to “Dockerfile” before running this command. Also, in the “requirements.txt” file the “tensorflow” command should be changed to “tensorflow-gpu”.

Here is an example for running the plugin on a GPU:

-------
> sudo docker run --runtime="nvidia" --privileged -v $(pwd)/data/ProstateX-0029:/incoming -v $(pwd)/output:/outgoing pl-neuproseg-gpu neuproseg.py --multistream /incoming /outgoing
-------


[1] https://github.com/NVIDIA/nvidia-docker 